### PR TITLE
Servehappy notice

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1605,6 +1605,31 @@ form.upgrade .hint {
 	}
 }
 
+.notice-upgrade-column-container {
+	display: -webkit-box;
+	display: flex;
+	-webkit-box-align: start;
+	align-items: flex-start;
+	-webkit-box-pack: justify;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	-webkit-box-orient: horizontal;
+	-webkit-box-direction: normal;
+	flex-flow: row wrap;
+}
+
+.notice-upgrade-column-container .notice-upgrade-column {
+	padding: 0 1em 1em 0;
+	flex-basis: 300px;
+	-webkit-box-flex: 1;
+	flex-grow: 1;
+}
+
+.wp-core-ui .button.button-hero.notice-upgrade-button {
+	display: block;
+	text-align: center;
+}
+
 
 /* @todo: this does not need its own section anymore */
 /*------------------------------------------------------------------------------

--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -71,6 +71,9 @@ add_filter( 'heartbeat_settings', 'wp_heartbeat_set_suspension' );
 // Nav Menu hooks.
 add_action( 'admin_head-nav-menus.php', '_wp_delete_orphaned_draft_menu_items' );
 
+// Notices hooks.
+add_action( 'admin_notices', 'wp_upgrade_php_notice' );
+
 // Plugin hooks.
 add_filter( 'whitelist_options', 'option_update_filter' );
 

--- a/src/wp-admin/includes/ms-admin-filters.php
+++ b/src/wp-admin/includes/ms-admin-filters.php
@@ -34,6 +34,7 @@ add_filter( 'import_allow_create_users', 'check_import_new_users' );
 // Notices Hooks
 add_action( 'admin_notices', 'site_admin_notice' );
 add_action( 'network_admin_notices', 'site_admin_notice' );
+add_action( 'network_admin_notices', 'wp_upgrade_php_notice' );
 
 // Update Hooks
 add_action( 'network_admin_notices', 'update_nag', 3 );

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -809,3 +809,56 @@ function wp_print_update_row_templates() {
 	</script>
 	<?php
 }
+
+/**
+ * Outputs an admin notice to inform the user of an unsupported PHP version in use.
+ *
+ * @since 4.9.4
+ */
+function wp_upgrade_php_notice() {
+	if ( ! current_user_can( 'upgrade_php' ) ) {
+		return;
+	}
+
+	if ( version_compare( phpversion(), '5.3.0', '>=' ) ) {
+		return;
+	}
+
+	$information_url = __( 'https://wordpress.org/support/upgrade-php/' );
+
+	?>
+	<div class="notice-upgrade notice notice-error is-dismissible">
+		<h2><?php _e( 'Your site could be faster and more secure!' ); ?></h2>
+
+		<p><?php _e( 'Hi, it&apos;s your friends at WordPress here. We noticed that your site is running on an outdated version of PHP, which is why we&apos;re showing you this notice.' ); ?></p>
+
+		<div class="notice-upgrade-column-container">
+
+			<div class="notice-upgrade-column">
+				<h3><?php _e( 'What is PHP and why should I care?' ); ?></h3>
+
+				<p><?php _e( 'PHP is the programming language that WordPress is built on. Newer versions of PHP are both faster and more secure, so upgrading is better for your site, and better for the people who are building WordPress.' ); ?></p>
+
+				<p><?php _e( 'If you want to know exactly how PHP works and why it is important, continue reading.' ); ?></p>
+			</div>
+
+			<div class="notice-upgrade-column">
+				<h3><?php _e( 'Okay, how do I update?' ); ?></h3>
+
+				<p><?php _e( 'The button below will take you to a page with more details on what PHP is, how to upgrade your PHP version, and what to do if it turns out you can&apos;t.' ); ?></p>
+
+				<p><a class="notice-upgrade-button button button-primary button-hero" href="<?php echo esc_url( $information_url ); ?>"><?php _e( 'Show me how to upgrade my PHP' ); ?></a></p>
+			</div>
+
+			<div class="notice-upgrade-column">
+				<h3><?php _e( 'Thank you for taking the time to read this!' ); ?></h3>
+
+				<p><?php _e( 'If you follow the instructions we&apos;ve provided to the letter, upgrading shouldn&apos;t take more than a few minutes, and it is generally very safe to do.' ); ?></p>
+
+				<p><?php _e( 'Good luck and happy blogging!' ); ?></p>
+			</div>
+
+		</div>
+	</div>
+	<?php
+}

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -813,7 +813,7 @@ function wp_print_update_row_templates() {
 /**
  * Determines whether to display an admin notice to inform the user of an unsupported PHP version in use.
  *
- * @since 4.9.5
+ * @since 5.0.0
  *
  * @return bool True if the notice should be displayed, false otherwise.
  */
@@ -834,7 +834,7 @@ function wp_should_display_upgrade_php_notice() {
 /**
  * Outputs an admin notice to inform the user of an unsupported PHP version in use.
  *
- * @since 4.9.5
+ * @since 5.0.0
  */
 function wp_upgrade_php_notice() {
 	if ( ! wp_should_display_upgrade_php_notice() ) {

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -826,7 +826,9 @@ function wp_should_display_upgrade_php_notice() {
 		return false;
 	}
 
-	return true;
+	$dismissed_pointers = explode( ',', (string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true ) );
+
+	return ! in_array( 'upgrade_php_notice', $dismissed_pointers, true );
 }
 
 /**
@@ -842,7 +844,7 @@ function wp_upgrade_php_notice() {
 	$information_url = __( 'https://wordpress.org/support/upgrade-php/' );
 
 	?>
-	<div class="notice-upgrade notice notice-error is-dismissible">
+	<div id="upgrade-php-notice" class="notice-upgrade notice notice-error is-dismissible">
 		<h2><?php _e( 'Your site could be faster and more secure!' ); ?></h2>
 
 		<p><?php _e( 'Hi, it&apos;s your friends at WordPress here. We noticed that your site is running on an outdated version of PHP, which is why we&apos;re showing you this notice.' ); ?></p>
@@ -876,4 +878,20 @@ function wp_upgrade_php_notice() {
 		</div>
 	</div>
 	<?php
+
+	// The following ensures dismissing the notice permanently dismisses it for the current user.
+	$script = <<<JS
+	document.getElementById( 'upgrade-php-notice' ).addEventListener( 'click', function( event ) {
+		if ( ! event.target.classList.contains( 'notice-dismiss' ) ) {
+			return;
+		}
+
+		wp.ajax.post( 'dismiss-wp-pointer', {
+			pointer: 'upgrade_php_notice'
+		});
+	});
+JS;
+
+	wp_enqueue_script( 'wp-util' );
+	wp_add_inline_script( 'wp-util', $script );
 }

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -811,16 +811,31 @@ function wp_print_update_row_templates() {
 }
 
 /**
+ * Determines whether to display an admin notice to inform the user of an unsupported PHP version in use.
+ *
+ * @since 4.9.4
+ *
+ * @return bool True if the notice should be displayed, false otherwise.
+ */
+function wp_should_display_upgrade_php_notice() {
+	if ( ! wp_is_php_version_outdated() ) {
+		return false;
+	}
+
+	if ( ! current_user_can( 'upgrade_php' ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
  * Outputs an admin notice to inform the user of an unsupported PHP version in use.
  *
  * @since 4.9.4
  */
 function wp_upgrade_php_notice() {
-	if ( ! current_user_can( 'upgrade_php' ) ) {
-		return;
-	}
-
-	if ( version_compare( phpversion(), '5.3.0', '>=' ) ) {
+	if ( ! wp_should_display_upgrade_php_notice() ) {
 		return;
 	}
 

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -813,7 +813,7 @@ function wp_print_update_row_templates() {
 /**
  * Determines whether to display an admin notice to inform the user of an unsupported PHP version in use.
  *
- * @since 4.9.4
+ * @since 4.9.5
  *
  * @return bool True if the notice should be displayed, false otherwise.
  */
@@ -834,7 +834,7 @@ function wp_should_display_upgrade_php_notice() {
 /**
  * Outputs an admin notice to inform the user of an unsupported PHP version in use.
  *
- * @since 4.9.4
+ * @since 4.9.5
  */
 function wp_upgrade_php_notice() {
 	if ( ! wp_should_display_upgrade_php_notice() ) {

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -550,6 +550,13 @@ function map_meta_cap( $cap, $user_id ) {
 				$caps[] = 'manage_options';
 			}
 			break;
+		case 'upgrade_php':
+			if ( is_multisite() && ! is_super_admin( $user_id ) ) {
+				$caps[] = 'do_not_allow';
+			} else {
+				$caps[] = 'update_core';
+			}
+			break;
 		default:
 			// Handle meta capabilities for custom post types.
 			global $post_type_meta_caps;

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6077,7 +6077,31 @@ All at ###SITENAME###
 }
 
 /**
- * Determines whether the currently active PHP version is outdated.
+ * Checks whether a given PHP version requirement is met.
+ *
+ * @since 4.9.4
+ *
+ * @param string $requirement Required PHP version to check against.
+ * @return bool True if the detected PHP version meets the given requirement, false otherwise.
+ */
+function wp_satisfies_php_version( $requirement ) {
+	/**
+	 * Filters the detected PHP version.
+	 *
+	 * The phpversion() function is used by default. This can be tweaked to account
+	 * for exotic setups.
+	 *
+	 * @since 4.9.4
+	 *
+	 * @param string $version Detected PHP version.
+	 */
+	$version = apply_filters( 'wp_detected_php_version', phpversion() );
+
+	return version_compare( $version, $requirement, '>=' );
+}
+
+/**
+ * Determines whether the currently active PHP version is considered outdated.
  *
  * The result of this function is not necessarily tied to whether the PHP version
  * is actually no longer supported.
@@ -6087,16 +6111,14 @@ All at ###SITENAME###
  * @return bool True if the PHP version is outdated, false otherwise.
  */
 function wp_is_php_version_outdated() {
-	$version  = phpversion();
-	$outdated = version_compare( $version, '5.3.0', '<' );
+	$outdated = ! wp_satisfies_php_version( '5.3.0' );
 
 	/**
 	 * Filters whether the currently active PHP version is outdated.
 	 *
 	 * @since 4.9.4
 	 *
-	 * @param bool $outdated  Whether the PHP version is outdated.
-	 * @param string $version Currently active PHP version.
+	 * @param bool $outdated Whether the PHP version is outdated.
 	 */
-	return apply_filters( 'wp_is_php_version_outdated', $outdated, $version );
+	return apply_filters( 'wp_is_php_version_outdated', $outdated );
 }

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6079,7 +6079,7 @@ All at ###SITENAME###
 /**
  * Checks whether a given PHP version requirement is met.
  *
- * @since 4.9.5
+ * @since 5.0.0
  *
  * @param string $requirement Required PHP version to check against.
  * @return bool True if the detected PHP version meets the given requirement, false otherwise.
@@ -6091,7 +6091,7 @@ function wp_satisfies_php_version( $requirement ) {
 	 * The phpversion() function is used by default. This can be tweaked to account
 	 * for exotic setups.
 	 *
-	 * @since 4.9.5
+	 * @since 5.0.0
 	 *
 	 * @param string $version Detected PHP version.
 	 */
@@ -6106,7 +6106,7 @@ function wp_satisfies_php_version( $requirement ) {
  * The result of this function is not necessarily tied to whether the PHP version
  * is actually no longer supported.
  *
- * @since 4.9.5
+ * @since 5.0.0
  *
  * @return bool True if the PHP version is outdated, false otherwise.
  */
@@ -6116,7 +6116,7 @@ function wp_is_php_version_outdated() {
 	/**
 	 * Filters whether the currently active PHP version is outdated.
 	 *
-	 * @since 4.9.5
+	 * @since 5.0.0
 	 *
 	 * @param bool $outdated Whether the PHP version is outdated.
 	 */

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6075,3 +6075,28 @@ All at ###SITENAME###
 		), $email_change_email['message'], $email_change_email['headers']
 	);
 }
+
+/**
+ * Determines whether the currently active PHP version is outdated.
+ *
+ * The result of this function is not necessarily tied to whether the PHP version
+ * is actually no longer supported.
+ *
+ * @since 4.9.4
+ *
+ * @return bool True if the PHP version is outdated, false otherwise.
+ */
+function wp_is_php_version_outdated() {
+	$version  = phpversion();
+	$outdated = version_compare( $version, '5.3.0', '<' );
+
+	/**
+	 * Filters whether the currently active PHP version is outdated.
+	 *
+	 * @since 4.9.4
+	 *
+	 * @param bool $outdated  Whether the PHP version is outdated.
+	 * @param string $version Currently active PHP version.
+	 */
+	return apply_filters( 'wp_is_php_version_outdated', $outdated, $version );
+}

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6079,7 +6079,7 @@ All at ###SITENAME###
 /**
  * Checks whether a given PHP version requirement is met.
  *
- * @since 4.9.4
+ * @since 4.9.5
  *
  * @param string $requirement Required PHP version to check against.
  * @return bool True if the detected PHP version meets the given requirement, false otherwise.
@@ -6091,7 +6091,7 @@ function wp_satisfies_php_version( $requirement ) {
 	 * The phpversion() function is used by default. This can be tweaked to account
 	 * for exotic setups.
 	 *
-	 * @since 4.9.4
+	 * @since 4.9.5
 	 *
 	 * @param string $version Detected PHP version.
 	 */
@@ -6106,7 +6106,7 @@ function wp_satisfies_php_version( $requirement ) {
  * The result of this function is not necessarily tied to whether the PHP version
  * is actually no longer supported.
  *
- * @since 4.9.4
+ * @since 4.9.5
  *
  * @return bool True if the PHP version is outdated, false otherwise.
  */
@@ -6116,7 +6116,7 @@ function wp_is_php_version_outdated() {
 	/**
 	 * Filters whether the currently active PHP version is outdated.
 	 *
-	 * @since 4.9.4
+	 * @since 4.9.5
 	 *
 	 * @param bool $outdated Whether the PHP version is outdated.
 	 */

--- a/tests/phpunit/tests/admin/includesUpdatePHP.php
+++ b/tests/phpunit/tests/admin/includesUpdatePHP.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @group admin
+ * @group upgrade
+ */
+class Tests_Admin_IncludesUpdatePHP extends WP_UnitTestCase {
+
+	protected static $user;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$user = $factory->user->create_and_get( array( 'role' => 'administrator' ) );
+
+		grant_super_admin( self::$user->ID );
+	}
+
+	public static function wpTearDownAfterClass() {
+		wp_delete_user( self::$user->ID );
+	}
+
+	public function test_display_notice_when_old_php() {
+		wp_set_current_user( self::$user->ID );
+		add_filter( 'wp_is_php_version_outdated', '__return_true' );
+
+		$this->assertTrue( wp_should_display_upgrade_php_notice() );
+	}
+
+	public function test_hide_notice_when_old_php() {
+		wp_set_current_user( self::$user->ID );
+		add_filter( 'wp_is_php_version_outdated', '__return_false' );
+
+		$this->assertFalse( wp_should_display_upgrade_php_notice() );
+	}
+
+	public function test_hide_notice_when_dismissed_pointer() {
+		wp_set_current_user( self::$user->ID );
+		add_filter( 'wp_is_php_version_outdated', '__return_true' );
+		update_user_meta( self::$user->ID, 'dismissed_wp_pointers', 'upgrade_php_notice' );
+
+		$this->assertFalse( wp_should_display_upgrade_php_notice() );
+	}
+
+	public function test_hide_notice_when_lacking_capabilities() {
+		wp_set_current_user( self::$user->ID );
+		add_filter( 'wp_is_php_version_outdated', '__return_true' );
+		add_filter( 'map_meta_cap', array( $this, 'filter_prevent_upgrade_php_cap' ), 10, 2 );
+
+		$this->assertFalse( wp_should_display_upgrade_php_notice() );
+	}
+
+	public function filter_prevent_upgrade_php_cap( $caps, $cap ) {
+		if ( 'upgrade_php' === $cap ) {
+			return array( 'do_not_allow' );
+		}
+
+		return $caps;
+	}
+}

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -236,6 +236,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 			'install_languages'      => array( 'administrator' ),
 			'update_languages'       => array( 'administrator' ),
 			'deactivate_plugins'     => array( 'administrator' ),
+			'upgrade_php'            => array( 'administrator' ),
 
 			'edit_categories'        => array( 'administrator', 'editor' ),
 			'delete_categories'      => array( 'administrator', 'editor' ),
@@ -267,6 +268,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 			'install_languages'      => array(),
 			'update_languages'       => array(),
 			'deactivate_plugins'     => array(),
+			'upgrade_php'            => array(),
 
 			'customize'              => array( 'administrator' ),
 			'delete_site'            => array( 'administrator' ),


### PR DESCRIPTION
This PR intends to introduce an admin notice about upgrading PHP into core.

Progress:
* [x] Handle whether a user is allowed to see the notice (regular site: admins, multisite: super admins).
* [x] Implement notice displaying, with markup and styles.
* [x] Display notice depending on PHP version active (currently: anywhere lower than 5.3.0).
* [ ] Review content and design.
* [ ] Consider creating a separate function for displaying the notice _unconditionally_.
* [x] Consider creating a separate function to check whether the current PHP version is considered outdated (i.e. whether the notice should be active).
* [x] Implement functionality to permanently dismiss the notice, or remove the dismissible functionality altogether.

Let's discuss the above steps and code, and go from here.