### PR TITLE
Allow for plugins to opt-out of Extension Pausing.

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -31,6 +31,7 @@
  *     Network: Optional. Specify "Network: true" to require that a plugin is activated
  *          across all sites in an installation. This will prevent a plugin from being
  *          activated on a single site when Multisite is enabled.
+ *     Allow Pausing: Optional. Specify "Allow Pausing: false" to disable extension pausing.
  *      * / # Remove the space to close comment
  *
  * Some users have issues with opening large files and manipulating the contents
@@ -46,6 +47,7 @@
  * reading.
  *
  * @since 1.5.0
+ * @since 5.1.0 Added 'AllowPausing' header.
  *
  * @param string $plugin_file Absolute path to the main plugin file.
  * @param bool   $markup      Optional. If the returned data should have HTML markup applied.
@@ -54,31 +56,33 @@
  * @return array {
  *     Plugin data. Values will be empty if not supplied by the plugin.
  *
- *     @type string $Name        Name of the plugin. Should be unique.
- *     @type string $Title       Title of the plugin and link to the plugin's site (if set).
- *     @type string $Description Plugin description.
- *     @type string $Author      Author's name.
- *     @type string $AuthorURI   Author's website address (if set).
- *     @type string $Version     Plugin version.
- *     @type string $TextDomain  Plugin textdomain.
- *     @type string $DomainPath  Plugins relative directory path to .mo files.
- *     @type bool   $Network     Whether the plugin can only be activated network-wide.
+ *     @type string $Name         Name of the plugin. Should be unique.
+ *     @type string $Title        Title of the plugin and link to the plugin's site (if set).
+ *     @type string $Description  Plugin description.
+ *     @type string $Author       Author's name.
+ *     @type string $AuthorURI    Author's website address (if set).
+ *     @type string $Version      Plugin version.
+ *     @type string $TextDomain   Plugin textdomain.
+ *     @type string $DomainPath   Plugins relative directory path to .mo files.
+ *     @type bool   $Network      Whether the plugin can only be activated network-wide.
+ *     @type bool   $AllowPausing Extension pausing support.
  * }
  */
 function get_plugin_data( $plugin_file, $markup = true, $translate = true ) {
 
 	$default_headers = array(
-		'Name'        => 'Plugin Name',
-		'PluginURI'   => 'Plugin URI',
-		'Version'     => 'Version',
-		'Description' => 'Description',
-		'Author'      => 'Author',
-		'AuthorURI'   => 'Author URI',
-		'TextDomain'  => 'Text Domain',
-		'DomainPath'  => 'Domain Path',
-		'Network'     => 'Network',
+		'Name'         => 'Plugin Name',
+		'PluginURI'    => 'Plugin URI',
+		'Version'      => 'Version',
+		'Description'  => 'Description',
+		'Author'       => 'Author',
+		'AuthorURI'    => 'Author URI',
+		'TextDomain'   => 'Text Domain',
+		'DomainPath'   => 'Domain Path',
+		'Network'      => 'Network',
+		'AllowPausing' => 'Allow Pausing',
 		// Site Wide Only is deprecated in favor of Network.
-		'_sitewide'   => 'Site Wide Only',
+		'_sitewide'    => 'Site Wide Only',
 	);
 
 	$plugin_data = get_file_data( $plugin_file, $default_headers, 'plugin' );
@@ -90,6 +94,7 @@ function get_plugin_data( $plugin_file, $markup = true, $translate = true ) {
 		$plugin_data['Network'] = $plugin_data['_sitewide'];
 	}
 	$plugin_data['Network'] = ( 'true' == strtolower( $plugin_data['Network'] ) );
+	$plugin_data['AllowPausing'] = 'false' !== strtolower( $plugin_data['AllowPausing'] );
 	unset( $plugin_data['_sitewide'] );
 
 	// If no text domain is defined fall back to the plugin slug.

--- a/src/wp-includes/error-protection.php
+++ b/src/wp-includes/error-protection.php
@@ -67,6 +67,17 @@ function wp_record_extension_error( $error ) {
 	if ( 0 === strpos( $error_file, $wp_plugin_dir ) ) {
 		$callback = 'wp_paused_plugins';
 		$path     = str_replace( $wp_plugin_dir . '/', '', $error_file );
+
+		if ( ! function_exists( 'get_plugin_data' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+		}
+
+		$plugin_data = get_plugin_data( $wp_plugin_dir . '/' . $path, false, false );
+
+		if ( ! $plugin_data['AllowPausing'] ) {
+			return false;
+		}
+
 	} else {
 		foreach ( $wp_theme_directories as $theme_directory ) {
 			$theme_directory = wp_normalize_path( $theme_directory );

--- a/tests/phpunit/tests/admin/includesPlugin.php
+++ b/tests/phpunit/tests/admin/includesPlugin.php
@@ -8,22 +8,23 @@ class Tests_Admin_includesPlugin extends WP_UnitTestCase {
 		$data = get_plugin_data( DIR_TESTDATA . '/plugins/hello.php' );
 
 		$default_headers = array(
-			'Name'        => 'Hello Dolly',
-			'Title'       => '<a href="http://wordpress.org/#">Hello Dolly</a>',
-			'PluginURI'   => 'http://wordpress.org/#',
-			'Description' => 'This is not just a plugin, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong: Hello, Dolly. When activated you will randomly see a lyric from Hello, Dolly in the upper right of your admin screen on every page. <cite>By <a href="http://ma.tt/">Matt Mullenweg</a>.</cite>',
-			'Author'      => '<a href="http://ma.tt/">Matt Mullenweg</a>',
-			'AuthorURI'   => 'http://ma.tt/',
-			'Version'     => '1.5.1',
-			'TextDomain'  => 'hello-dolly',
-			'DomainPath'  => '',
+			'Name'         => 'Hello Dolly',
+			'Title'        => '<a href="http://wordpress.org/#">Hello Dolly</a>',
+			'PluginURI'    => 'http://wordpress.org/#',
+			'Description'  => 'This is not just a plugin, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong: Hello, Dolly. When activated you will randomly see a lyric from Hello, Dolly in the upper right of your admin screen on every page. <cite>By <a href="http://ma.tt/">Matt Mullenweg</a>.</cite>',
+			'Author'       => '<a href="http://ma.tt/">Matt Mullenweg</a>',
+			'AuthorURI'    => 'http://ma.tt/',
+			'Version'      => '1.5.1',
+			'TextDomain'   => 'hello-dolly',
+			'DomainPath'   => '',
+			'AllowPausing' => true,
 		);
 
 		$this->assertTrue( is_array( $data ) );
 
 		foreach ( $default_headers as $name => $value ) {
-			$this->assertTrue( isset( $data[ $name ] ) );
-			$this->assertEquals( $value, $data[ $name ] );
+			$this->assertTrue( isset( $data[ $name ] ), 'Header ' . $name );
+			$this->assertEquals( $value, $data[ $name ], 'Header ' . $name );
 		}
 	}
 


### PR DESCRIPTION
Introduces a new plugin header "Allow Pausing". Adding
"Allow Pausing: false" to the plugin header will bail out of recording
the extension error.